### PR TITLE
Mostra un text i enllaç al Viccionari més correcte

### DIFF
--- a/extractor/extract.py
+++ b/extractor/extract.py
@@ -320,13 +320,14 @@ def _set_definition(lemma, tenses, definitions):
     defintion = {}
     if lemma in definitions:
         defintion["definition"] = definitions[lemma]
-        defintion["definition_credits"] = "La descripció del verb prové del Viccionari amb " \
-        "<a href='https://creativecommons.org/licenses/by-sa/3.0/deed.ca'>Llicència de Creative Commons Reconeixement/Compartir-Igual</a>. " \
-        f"Podeu millorar aquesta descripció fent clic en <a href='https://ca.wiktionary.org/wiki/{lemma}'>{lemma}</a>."
+        defintion["definition_credits"] = "La definició del verb prové del Viccionari i està sotmesa " \
+        "a les condicions de la llicència Creative Commons " \
+        "<a href='https://creativecommons.org/licenses/by-sa/3.0/deed.ca'>Reconeixement-CompartirIgual (CC BY-SA 3.0)</a>. " \
+        f"Podeu millorar-la editant <a href='https://ca.wiktionary.org/wiki/{lemma}'>la seva entrada al Viccionari</a>."
     else:
         defintion["definition_url"] = f"https://dlc.iec.cat/results.asp?txtEntrada={lemma}"
-        defintion["definition_credits"] = "Aquest verb no existeix en el Viccionari, que és la font que usem per a les definicions. " \
-        f"Podeu crear-la fent clic en <a href='https://ca.wiktionary.org/wiki/{lemma}'>{lemma}</a>."
+        defintion["definition_credits"] = "Aquest verb no és al Viccionari, que és la font que usem per a les definicions. " \
+        f"Podeu afegir la definició creant <a href='https://ca.wiktionary.org/wiki/{lemma}'>la seva entrada al Viccionari</a>."
 
     defintion["title"] = reflexius.get_reflexiu(lemma)
     tenses.insert(0, defintion)


### PR DESCRIPTION
- Canvio "descripció" per "definició"
- Corregeixo el nom de la llicència
- Redacto millor el text
- Milloro el text enllaçat al Viccionari
- Canvio algun "no existeix en" per "no és al", em sona més bé