### PR TITLE
fix(search): solve error 500 on searching "anar" and its conjugations (#57)

### DIFF
--- a/web/models/search.py
+++ b/web/models/search.py
@@ -19,10 +19,11 @@ class SearchVerbInformation(BaseModel):  # noqa: D101
 
 
 class SearchVerbMetadata(BaseModel):  # noqa: D101
-    definition: str
+    definition: str | None = None
     definition_credits: str
     title: str
     infinitive: str
+    note: str | None = None
 
 
 type VerbEntry = SearchVerbInformation | SearchVerbMetadata


### PR DESCRIPTION
Aquesta simple PR afegeix el camp `note` com a opcional a les metadades dels verbs cercats i també canvia el camp `definition` a opcional per a solucionar el bug ocasionat pel verb `anar` i la seva forma auxiliar.

En principi tancaria la issue #57.